### PR TITLE
Update futureTasks: Improve docs to explain how the filter works

### DIFF
--- a/futureTasks
+++ b/futureTasks
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """
-filter incoming lines based on date threshold
+Filter incoming lines based on date threshold.
 
-Threshold markers are of the form "t:YYYY-MM-DD".
+This this tasks containing a date threshold (t:YYYY-MM-DD) until the specified point in the future.
 
 This is intended to be used as TODOTXT_FINAL_FILTER.
 """


### PR DESCRIPTION
Before the docs only mentioned that was some kind of date-based filtering being done, but didn't explain what.

The new docs now clarify that the purpose of the filter is to hide entries marked as being in the future.
