### PR TITLE
Allow setting a TODO_EDITOR different from the default EDITOR

### DIFF
--- a/edit
+++ b/edit
@@ -12,7 +12,9 @@ function usage() {
 
 [ "$action" = "usage" ] && usage
 
-cmd=${EDITOR:-vi}
+todo_edit=${TODO_EDITOR:-$EDITOR}
+cmd=${todo_edit:-vi}
+
 if [[ "$1" =~ ^[0-9]+$ ]]; then
 	cmd="$cmd +$1"
 fi


### PR DESCRIPTION
Allow setting a TODO_EDITOR which differs from the default shell editor variable, this can be set via the todo config file

In my case .todo/todo.cfg

```
export TODO_EDITOR=mate
```
