### PR TITLE
Headup time in days added tag: "h:<days>"

### DIFF
--- a/futureTasks
+++ b/futureTasks
@@ -1,35 +1,53 @@
 #!/usr/bin/env python
-
 """
 filter incoming lines based on date threshold
 
-hides tasks marked with a date threshold ("t:YYYY-MM-DD") in the future
+Threshold markers are of the form "t:YYYY-MM-DD".
+A headup h:DD will start showing DD days ahead of the t: date.
 
-this is intended to be used as TODOTXT_FINAL_FILTER
+This is intended to be used as TODOTXT_FINAL_FILTER.
 """
 
 import sys
 import re
 
-from datetime import datetime
+import datetime
 
 
 pattern = re.compile(r"t:(\d{4})-(\d{2})-(\d{2})")
+hpattern = re.compile(r"h:(\d+)")
 
 
-def main(args=None):
-	now = datetime.now()
-	for line in sys.stdin:
-		match = pattern.search(line)
-		if match:
-			threshold = [int(i) for i in match.groups()]
-			if datetime(*threshold) < now:
-				print(line.strip())
-		else:
-			print(line.strip())
-	return True
+def usage():
+    print('futureTasks threshold markers are of the form \
+"t:YYYY-MM-DD [h:{days}]"')
+
+
+def main(argv):
+    if len(argv) > 1 and argv[1] == "usage":
+        usage()
+        sys.exit(2)
+    now = datetime.datetime.now()
+    for line in sys.stdin:
+        match = pattern.search(line)
+        if match:
+            threshold = [int(i) for i in match.groups()]
+
+            # get pattern of the form h:{days} if present
+            hmatch = hpattern.search(line)
+            if hmatch:
+                headup = int(hmatch.groups()[0])
+            else:
+                headup = 0
+
+            if datetime.datetime(*threshold) < now + \
+                    datetime.timedelta(days=headup):
+                print(line.strip())
+        else:
+            print(line.strip())
+    return True
 
 
 if __name__ == "__main__":
-	status = not main(sys.argv)
-	sys.exit(status)
+    status = not main(sys.argv)
+    sys.exit(status)


### PR DESCRIPTION
I use futuretasks a lot. Additionally, i wanted to have a warning period before the due date. My patch implements the h:<days> tag which lets you specify a headup period in days.